### PR TITLE
Adds wagtailvideos library to include uploadable videos

### DIFF
--- a/SCUP/settings/base.py
+++ b/SCUP/settings/base.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     "data",
     "instrument",
     "search",
+    "wagtailvideos",
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",
     "wagtail.embeds",

--- a/home/models.py
+++ b/home/models.py
@@ -3,6 +3,8 @@ from django.db import models
 from wagtail.models import Page
 from wagtail.fields import RichTextField
 from wagtail.admin.edit_handlers import FieldPanel
+from wagtailvideos.edit_handlers import VideoChooserPanel
+
 
 class HomePage(Page):
     About_GDC = RichTextField(blank=True)
@@ -10,7 +12,6 @@ class HomePage(Page):
     Section1_Header = RichTextField(blank=True)
     Section1_Content = RichTextField(blank=True)
     Section2_Header = RichTextField(blank=True)
-    Section2_Content = RichTextField(blank=True)
     gdc_bio_right_header = RichTextField(blank=True)
     gdc_bio_right_text = RichTextField(blank=True)
 
@@ -34,6 +35,11 @@ class HomePage(Page):
     timeline_4_header = RichTextField(blank=True)
     timeline_4_bio = RichTextField(blank=True)    
     timeline_footer = RichTextField(blank=True)
+
+    gdc_about_video = models.ForeignKey('wagtailvideos.Video',
+                                        related_name='+',
+                                        null=True,
+                                        on_delete=models.SET_NULL)
 
     aether_logo = models.ForeignKey(
         'wagtailimages.Image',
@@ -101,7 +107,6 @@ class HomePage(Page):
         FieldPanel('Section1_Header'),
         FieldPanel('Section1_Content'),
         FieldPanel('Section2_Header'),
-        FieldPanel('Section2_Content'),
         FieldPanel('gdc_bio_right_header'),
         FieldPanel('gdc_bio_right_text'),
         FieldPanel('instruments_bio'),
@@ -122,6 +127,7 @@ class HomePage(Page):
         FieldPanel('timeline_4_date'),
         FieldPanel('timeline_4_header'),
         FieldPanel('timeline_4_bio'),
-        FieldPanel('timeline_footer')
+        FieldPanel('timeline_footer'),
+        VideoChooserPanel('gdc_about_video')
     ]
 

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -10,6 +10,7 @@
 
 {% block content %}
 {% load wagtailimages_tags %}
+{% load wagtailvideos_tags %}
 <body id="page-top">
     <!-- Masthead-->
     <header class="masthead">
@@ -41,7 +42,7 @@
                         <i class="fas fa-laptop fa-stack-1x fa-inverse"></i>
                     </span>
                     <h4 class="my-3">{{ page.Section2_Header|richtext }}</h4>
-                    <p class="text-muted">{{ page.Section2_Content|richtext }}</p>
+                    {% video self.gdc_about_video controls width=350 %}
                 </div>
                 <div class="col-md-4">
                     <span class="fa-stack fa-4x">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django>=4.1,<4.2
 wagtail>=4.1,<4.2
+wagtailvideos>=4.0.1


### PR DESCRIPTION
This pull-request implements the wagtailvideos library (https://pypi.org/project/wagtailvideos/) for incorporating upload-able videos into the SCUP. The uploader is exposed on the admin page similar to the 'image' chooser, and is implemented for the 'About GDC' video on the homepage.
![Local test example](https://user-images.githubusercontent.com/14282852/205362887-d9bd7243-2ca4-4597-aa21-1ece0a7b369b.PNG)
