### PR TITLE
Fixing CSRF implementation and Git issues with media

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,5 +144,6 @@ SCUP/migrations/*
 migrations/*
 data/migrations/*
 instrument/migrations/*
+media
 media/images
 media/original_images

--- a/SCUP/settings/base.py
+++ b/SCUP/settings/base.py
@@ -174,3 +174,5 @@ WAGTAILSEARCH_BACKENDS = {
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 WAGTAILADMIN_BASE_URL = "http://example.com"
+
+CSRF_TRUSTED_ORIGINS = SETTINGS_JSON_PARSED["CSRF_TRUSTED_ORIGINS"]


### PR DESCRIPTION
This pull-request implements the "CSRF_TRUSTED_ORIGINS" parameter in the settings file for Django which will fix the invalid CSRF errors that have been seen. Additionally, this removes the .keep file in the 'media' directory and adds the whole directory to .gitignore as it's not necessary to track in CM, and is nominally locked down to only be accessed by the Apache host user.