### PR TITLE
Feature/move data levels to sidebar

### DIFF
--- a/data/templates/data/data_page.html
+++ b/data/templates/data/data_page.html
@@ -42,7 +42,7 @@
     </div>
 
     <div class="dataForm">
-      <label class="my-1 mr-2" for="selectDataLevel">Data Level</label>
+      <label class="my-1 mr-2" for="selectDataLevel">Data Level <a data-bs-toggle="offcanvas" href="#dataLevelsExpanded" role="button" aria-controls="dataLevelsExpanded">(?)</a></label>
       <select class="custom-select my-1 mr-sm-2" id="selectDataLevel">
         <option value="0"></option>
         <option value="1">QL</option>
@@ -64,13 +64,9 @@
 
   <ul id="dataList" class="list-group"></ul>
   
-  <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasExample" aria-controls="offcanvasExample">
-    Button with data-bs-target
-  </button>
-  
-  <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvasExample" aria-labelledby="offcanvasExampleLabel">
+  <div class="offcanvas offcanvas-start" tabindex="-1" id="dataLevelsExpanded" aria-labelledby="dataLevelsExpandedLabel">
     <div class="offcanvas-header">
-      <h5 class="offcanvas-title" id="offcanvasExampleLabel">Data Level Definitions</h5>
+      <h5 class="offcanvas-title" id="dataLevelsExpandedLabel">Data Level Definitions</h5>
       <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body">

--- a/data/templates/data/data_page.html
+++ b/data/templates/data/data_page.html
@@ -42,8 +42,7 @@
     </div>
 
     <div class="dataForm">
-      <label class="my-1 mr-2" for="selectDataLevel">Data Level <a href="#" data-bs-html="true" data-bs-toggle="tooltip" data-bs-placement="right" 
-        data-bs-title="Level 0: Instrument science data at full resolution, time ordered, with duplicates and transmission errors removed<br>Level 1: Processed to represent physical units, resampled, calibrated, and packaged with ancillary<br>Level 2: Official science data product including geophysical parameters from instruments, derived data products, and located in space and time commensurate with instrument location, pointing and sampling<br>QL: Science & engineering telemetry data stream">(?)</a></label>
+      <label class="my-1 mr-2" for="selectDataLevel">Data Level</label>
       <select class="custom-select my-1 mr-sm-2" id="selectDataLevel">
         <option value="0"></option>
         <option value="1">QL</option>
@@ -64,6 +63,26 @@
   </div>
 
   <ul id="dataList" class="list-group"></ul>
+  
+  <button class="btn btn-primary" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasExample" aria-controls="offcanvasExample">
+    Button with data-bs-target
+  </button>
+  
+  <div class="offcanvas offcanvas-start" tabindex="-1" id="offcanvasExample" aria-labelledby="offcanvasExampleLabel">
+    <div class="offcanvas-header">
+      <h5 class="offcanvas-title" id="offcanvasExampleLabel">Data Level Definitions</h5>
+      <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+      <div>
+        <b>Level 0:</b> Instrument science data at full resolution, time ordered, with duplicates and transmission errors removed<br>
+        <b>Level 1:</b> Processed to represent physical units, resampled, calibrated, and packaged with ancillary<br>
+        <b>Level 2:</b> Official science data product including geophysical parameters from instruments, derived data products, and located in space and time commensurate with instrument location, pointing and sampling<br>
+        <b>QL:</b> Science & engineering telemetry data stream
+      </div>
+    </div>
+  </div>
+
 </body>
 {% endblock %}
 


### PR DESCRIPTION
This pull-request implements a sidebar for the data level definitions to de-clutter the UI.

The nominal UI for the data page looks the same as before, with a "(?)" following the data levels which can be clicked to pop-out the sidebar.
![DataLevelExample](https://user-images.githubusercontent.com/14282852/205754174-c58efa00-c0c7-4af6-8551-ccb398210986.PNG)

The sidebar appears on the left and describes each data level - it can be closed through the X, or clicking anywhere outside the sidebar.
![DataLevelExamplePopout](https://user-images.githubusercontent.com/14282852/205754169-073f5ae8-8b0c-402e-9a22-f4293dba6939.PNG)
